### PR TITLE
Add timeout to RelpTCPClient.close().

### DIFF
--- a/relppy/client.py
+++ b/relppy/client.py
@@ -64,9 +64,17 @@ class RelpTCPClient:
         self.connected = True
         return sock
 
-    def close(self):
+    def close(self, timeout=1):
         if hasattr(self, "sock"):
             _log.debug("closing %s", self)
+            if timeout > 0:
+                _log.debug("waiting for timeout %s", timeout)
+                wait_counter = 0
+                while len(self.resendbuf) > 0:
+                    wait_counter += 1
+                    if wait_counter >= (timeout * 100):
+                        break
+                    time.sleep(0.01)
             resendbuf = self.resendbuf
             self.resendbuf = {}
             _log.debug("resendbuf: %s", len(resendbuf))

--- a/relppy/client.py
+++ b/relppy/client.py
@@ -1,4 +1,5 @@
 import socket
+import concurrent
 from concurrent.futures import ThreadPoolExecutor, Future
 import threading
 import time

--- a/relppy/client.py
+++ b/relppy/client.py
@@ -69,12 +69,7 @@ class RelpTCPClient:
             _log.debug("closing %s", self)
             if timeout > 0:
                 _log.debug("waiting for timeout %s", timeout)
-                wait_counter = 0
-                while len(self.resendbuf) > 0:
-                    wait_counter += 1
-                    if wait_counter >= (timeout * 100):
-                        break
-                    time.sleep(0.01)
+                concurrent.futures.wait([x[1] for x in self.resendbuf.values()], timeout)
             resendbuf = self.resendbuf
             self.resendbuf = {}
             _log.debug("resendbuf: %s", len(resendbuf))


### PR DESCRIPTION
When calling RelpTCPClient.close() shortly after the last message was sent its likely to get a "txnr does not found" error because the ACK was not received yet. Using a timeout value of e.g. 1 fixes this issue.