### PR TITLE
Add logging RelpHandler() and cli commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ loggers on exit.
 import logging
 from relppy.log_handler import RelpHandler
 
-log_handler = RelpHandler(address="server:port", facility="LOCAL7")
+log_handler = RelpHandler(address=(server, port), facility="LOCAL7")
 
 formatter = logging.Formatter('%(name)s: [%(levelname)s] %(message)s')
 log_handler.setFormatter(formatter)
@@ -89,7 +89,7 @@ context = ssl.create_default_context(
 context.load_cert_chain(certfile="/path/to/client-cert.pem",
                         keyfile="/path/to/client-key.pem")
 
-log_handler = RelpHandler(address="server:port",
+log_handler = RelpHandler(address=(server, port),
                         facility="LOCAL7",
                         context=context)
 

--- a/README.md
+++ b/README.md
@@ -37,3 +37,77 @@ with RelpTCPClient(("localhost", 10514)) as cl:
         res = fut.result()
         print(f"sent: {m} -> {res}")
 ```
+
+## log handler
+
+relppy comes with a logging handler that can be used with [python logging](https://docs.python.org/3/library/logging.html).
+The handler has four special arguments.
+
+### spool_method=\<function>
+You can specify a spool method. This method is called with the log record instance as argument if the record could not be
+sent (e.g. relp log server down) to spool it for later resend. Writing the spool/resend methods is up to the developer.
+
+### exception_on_emit=\<bool>
+If exception_on_emit is True, the emit() method of the log handler raises an exception if the log message could
+not be sent. This results in an exception (e.g. Connection refused) when calling the logger (e.g. logger.info). This
+behavior is intended to be used in the resend method (see spool_method above) to ensure all spooled
+messages are delivered to the relp log server.
+
+### logger=\<logging.Logger>
+The logger instance that is used to log connection failures.
+
+### active_log_handlers=\<List>
+A list that the log handler is added to on __init__ and removed from on close().
+This is useful in multiprocessing programs/daemons to close all open
+loggers on exit.
+
+### Examples
+
+```python
+import logging
+from relppy.log_handler import RelpHandler
+
+log_handler = RelpHandler(address="server:port", facility="LOCAL7")
+
+formatter = logging.Formatter('%(name)s: [%(levelname)s] %(message)s')
+log_handler.setFormatter(formatter)
+logger = logging.getLogger("my_logger")
+logger.addHandler(log_handler)
+```
+
+Passing a SSL context enables TLS.
+
+```python
+import ssl
+import logging
+from relppy.log_handler import RelpHandler
+
+context = ssl.create_default_context(
+    purpose=ssl.Purpose.SERVER_AUTH,
+    cafile="/path/to/ca.cert",
+)
+context.load_cert_chain(certfile="/path/to/client-cert.pem",
+                        keyfile="/path/to/client-key.pem")
+
+log_handler = RelpHandler(address="server:port",
+                        facility="LOCAL7",
+                        context=context)
+
+formatter = logging.Formatter('%(name)s: [%(levelname)s] %(message)s')
+log_handler.setFormatter(formatter)
+
+logger = logging.getLogger("my_logger")
+logger.addHandler(log_handler)
+```
+
+## CLI command
+
+relppy comes with a CLI command to send messages to a relp server [rsyslog example](https://github.com/the2nd/relppy/blob/main/rsyslog/rsyslog-ssl.conf).
+
+```bash
+relppy logger --logger-name audit-log --host servername --port port --log-level INFO --priority info --facility LOCAL7 "Test message"
+```
+
+```bash
+relppy logger-tls --logger-name audit-log --host servername --port port --cafile /path/to/syslog-ca.pem --certfile /path/to/syslog-cert.pem --keyfile /path/to/syslog-key.pem --log-level INFO --priority info --facility LOCAL7 "Test message via TLS"
+```

--- a/relppy/client.py
+++ b/relppy/client.py
@@ -215,7 +215,7 @@ class RelpTCPClient:
                     _log.warning("buffer full: bufsize=%s", len(self.resendbuf))
                     try_resend = True
                 if (time.time() - self.last_resend) >= self.resend_interval:
-                    if len(self.resendbuf) > 1:
+                    if len(self.resendbuf) > 0:
                         _log.warning("buffer resend interval reached: resend_interval=%s", self.resend_interval)
                         try_resend = True
                 if try_resend:

--- a/relppy/client.py
+++ b/relppy/client.py
@@ -206,7 +206,7 @@ class RelpTCPClient:
                     data = send_data['data']
                     skip_buffer = send_data['skip_buffer']
                     new_conn = send_data['new_conn']
-                except Exception as e:
+                except Exception:
                     _log.warning("received wrong send data: %s", send_data)
                     continue
             if not skip_buffer:
@@ -285,6 +285,7 @@ class RelpTCPClient:
             raise exception
         future = status_data['future']
         return future
+
 
 class RelpUnixClient(RelpTCPClient):
     def create_connection(self, address, **kwargs):

--- a/relppy/log_handler.py
+++ b/relppy/log_handler.py
@@ -7,6 +7,7 @@ import logging.handlers
 from .client import RelpTlsClient
 from .client import RelpTCPClient
 
+
 class RelpHandler(logging.handlers.SysLogHandler):
     def __init__(
         self,
@@ -24,7 +25,7 @@ class RelpHandler(logging.handlers.SysLogHandler):
         facility_id = "LOG_%s" % facility
         try:
             facility = getattr(logging.handlers.SysLogHandler, facility_id)
-        except:
+        except Exception:
             msg = "Unknown facility: %s" % facility
             raise Exception(msg)
 
@@ -112,7 +113,7 @@ class RelpHandler(logging.handlers.SysLogHandler):
                         # Try to resend message.
                         try:
                             self.relp_client.send_command(b"syslog", msg)
-                        except Exception as e:
+                        except Exception:
                             self.connection_broken = True
                             spool_message = True
                         else:

--- a/relppy/log_handler.py
+++ b/relppy/log_handler.py
@@ -127,5 +127,5 @@ class RelpHandler(logging.handlers.SysLogHandler):
                         self.spool_method(record)
                     except Exception as e:
                         msg = "Failed to spool record: %s" % e
-                        self.logging.warning(msg)
+                        self.logger.warning(msg)
             self.handleError(record)

--- a/relppy/log_handler.py
+++ b/relppy/log_handler.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+import time
+import socket
+import logging
+import logging.handlers
+
+from .client import RelpTlsClient
+from .client import RelpTCPClient
+
+class RelpHandler(logging.handlers.SysLogHandler):
+    def __init__(
+        self,
+        address,
+        facility,
+        context=None,
+        reconnect_timeout=1,
+        logger=None,
+        spool_method=None,
+        exception_on_emit=False,
+        active_log_handlers=[],
+        **kwargs,
+        ):
+
+        facility_id = "LOG_%s" % facility
+        try:
+            facility = getattr(logging.handlers.SysLogHandler, facility_id)
+        except:
+            msg = "Unknown facility: %s" % facility
+            raise Exception(msg)
+
+        if logger:
+            self.logger = logger
+        else:
+            self.logger = logging.getLogger(__name__)
+
+        self.address = address
+        self.context = context
+        self.facility = facility
+        self.relp_client = None
+        self.spool_method = spool_method
+        self.exception_on_emit = exception_on_emit
+        self.connection_broken = False
+        self.active_log_handlers = active_log_handlers
+        self.kwargs = kwargs
+        logging.Handler.__init__(self)
+        self.active_log_handlers.append(self)
+
+    def createSocket(self):
+        try:
+            if self.context:
+                self.relp_client = RelpTlsClient(address=self.address,
+                                                context=self.context,
+                                                server_hostname=self.address[0],
+                                                **self.kwargs)
+            else:
+                self.relp_client = RelpTCPClient(address=self.address, **self.kwargs)
+        except Exception as e:
+            self.connection_broken = True
+            msg = ("Failed to connect to relp log server: %s: %s"
+                    % (self.address, e))
+            self.logger.warning(msg)
+            raise
+
+    def close(self):
+        self.acquire()
+        try:
+            if self.relp_client:
+                self.relp_client.close()
+                self.relp_client = None
+            logging.Handler.close(self)
+        finally:
+            try:
+                self.active_log_handlers.remove(self)
+            except ValueError:
+                pass
+            self.release()
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            if self.ident:
+                msg = self.ident + msg
+            if self.append_nul:
+                msg += '\000'
+
+            # We need to convert record level to lowercase, maybe this will
+            # change in the future.
+            prio = '<%d>' % self.encodePriority(self.facility,
+                                                self.mapPriority(record.levelname))
+            prio = prio.encode('utf-8')
+            # Message is a string. Convert to bytes as required by RFC 5424
+            msg = msg.encode('utf-8')
+            msg = prio + msg
+
+            if not self.relp_client:
+                self.createSocket()
+            self.relp_client.send_command(b"syslog", msg)
+            self.connection_broken = False
+        except Exception as e:
+            if self.exception_on_emit:
+                raise
+            spool_message = False
+            # On socket error try to resend message.
+            if isinstance(e, socket.error):
+                if self.connection_broken:
+                    spool_message = True
+                else:
+                    reconnect_start = time.time()
+                    while True:
+                        if (time.time() - reconnect_start) >= self.reconnect_timeout:
+                            break
+                        # Try to resend message.
+                        try:
+                            self.relp_client.send_command(b"syslog", msg)
+                        except Exception as e:
+                            self.connection_broken = True
+                            spool_message = True
+                        else:
+                            self.connection_broken = False
+                            spool_message = False
+                            break
+            else:
+                spool_message = True
+            if spool_message:
+                if self.spool_method:
+                    try:
+                        self.spool_method(record)
+                    except Exception as e:
+                        msg = "Failed to spool record: %s" % e
+                        self.logging.warning(msg)
+            self.handleError(record)

--- a/relppy/main.py
+++ b/relppy/main.py
@@ -250,6 +250,7 @@ def logger_tls_options(func):
         return func(context=context, **kwargs)
     return _
 
+
 @cli.command()
 @hostport_option
 @logger_tls_options
@@ -280,6 +281,7 @@ def logger_tls(address: tuple[str, int], message: str, logger_name: str,
     finally:
         log_handler.close()
 
+
 @cli.command()
 @hostport_option
 @click.option("--logger-name", type=str, default="RELP", show_default=True)
@@ -308,6 +310,7 @@ def logger(address: tuple[str, int], message: str, logger_name: str, log_level: 
         log_method(message)
     finally:
         log_handler.close()
+
 
 if __name__ == "__main__":
     cli()

--- a/rsyslog/rsyslog-ssl.conf
+++ b/rsyslog/rsyslog-ssl.conf
@@ -1,0 +1,35 @@
+# CA cert.
+# openssl genrsa -out ca-key.pem 4096
+# openssl req -new -x509 -days 365 -key ca-key.pem -out ca.pem
+
+# Server cert.
+# openssl genrsa -out server-key.pem 4096
+# openssl req -new -key server-key.pem -out server.csr
+# openssl x509 -req -days 365 -in server.csr -CA ca.pem -CAkey ca-key.pem -out server-cert.pem
+
+# Client cert.
+# openssl genrsa -out client-key.pem 4096
+# openssl req -new -key client-key.pem -out client.csr
+# openssl x509 -req -days 365 -in client.csr -CA ca.pem -CAkey ca-key.pem -out client-cert.pem
+
+#$AllowedSender TCP, 192.168.1.1, 192.168.1.2, 192.168.1.3
+
+# Enable debug logging.
+#$DebugLevel 2
+#$DebugFile /var/log/rsyslog-debug.log
+
+# Ruleset to write to logfile.
+ruleset (name="relp") { action(type="omfile" file="/var/log/relp.log") }
+
+# Load relp module.
+module(load="imrelp" ruleset="relp")
+
+# Setup relp module with TLS enabled.
+input(type="imrelp" port="20514"
+	tls="on"
+	tls.caCert="/etc/rsyslog.d/ssl/ca.pem"
+	tls.myCert="/etc/rsyslog.d/ssl/server-cert.pem"
+	tls.myPrivKey="/etc/rsyslog.d/ssl/server-key.pem"
+	tls.authMode="name"
+	tls.permittedpeer=["node1.domain.tld","node2.domain.tld","node3.domain.tld","node4.domain.tld"]
+)


### PR DESCRIPTION
Add RelpHandler() classs to be used with python logging framework. It supports TCP and TCP/TLS connections via RelpTCPClient() and RelpTlsClient() classes. Also add cli commands "logger" and "logger-tls" to send messages from shell.

This PR addresses #13.